### PR TITLE
Removed pyairports dependency

### DIFF
--- a/goedelv2.yml
+++ b/goedelv2.yml
@@ -176,7 +176,6 @@ dependencies:
       - protobuf==4.25.7
       - psutil==6.1.0
       - py-cpuinfo==9.0.0
-      - pyairports==2.1.1
       - pyarrow==18.1.0
       - pycountry==24.6.1
       - pycparser==2.22


### PR DESCRIPTION
Currently the pyairports package is not on PyPI anymore, which causes errors during installation. The package can be removed from the dependency list since it is not needed anyway.